### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,136 +1,136 @@
 ##################################################
-#					 Device     				 #
+#                  Device                        #
 ##################################################
-Device									KEYWORD1
-begin									KEYWORD2
-end										KEYWORD2
-isInitialized							KEYWORD2
+Device	KEYWORD1
+begin	KEYWORD2
+end	KEYWORD2
+isInitialized	KEYWORD2
 ##################################################
-#					Printable     				 #
+#                  Printable                     #
 ##################################################
-Printable								KEYWORD1
-toString								KEYWORD2
+Printable	KEYWORD1
+toString	KEYWORD2
 ##################################################
-#					Utilities     				 #
+#                  Utilities                     #
 ##################################################
-Utilities								KEYWORD1
-EasyMalloc								KEYWORD2
-ZeroBuffer								KEYWORD2
-OverrideLastStringChar					KEYWORD2
-OverrideLastTwoChar						KEYWORD2
+Utilities	KEYWORD1
+EasyMalloc	KEYWORD2
+ZeroBuffer	KEYWORD2
+OverrideLastStringChar	KEYWORD2
+OverrideLastTwoChar	KEYWORD2
 ##################################################
-#					 Button     				 #
+#                  Button                        #
 ##################################################
-Button									KEYWORD1
-isPressed								KEYWORD2
-getPressedTimeMilliseconds				KEYWORD2
-getPressedTimeSeconds					KEYWORD2
+Button	KEYWORD1
+isPressed	KEYWORD2
+getPressedTimeMilliseconds	KEYWORD2
+getPressedTimeSeconds	KEYWORD2
 ##################################################
-#					 RGBLed     				 #
+#                  RGBLed                        #
 ##################################################
-RGBLed									KEYWORD1
-begin									KEYWORD2
-end										KEYWORD2
-turnOff									KEYWORD2
-setColor								KEYWORD2
+RGBLed	KEYWORD1
+begin	KEYWORD2
+end	KEYWORD2
+turnOff	KEYWORD2
+setColor	KEYWORD2
 ##################################################
-#					  Relay     				 #
+#                  Relay                         #
 ##################################################
-Relay									KEYWORD1
-begin									KEYWORD2
-end										KEYWORD2
-turnOn									KEYWORD2
-turnOff									KEYWORD2
-isOn									KEYWORD2
+Relay	KEYWORD1
+begin	KEYWORD2
+end	KEYWORD2
+turnOn	KEYWORD2
+turnOff	KEYWORD2
+isOn	KEYWORD2
 ##################################################
-#					RelayNamed     				 #
+#                  RelayNamed                    #
 ##################################################
-RelayNamed								KEYWORD1
-toString								KEYWORD2
+RelayNamed	KEYWORD1
+toString	KEYWORD2
 ##################################################
-#				   DistanceMeter     			 #
+#                  DistanceMeter                 #
 ##################################################
-DistanceMeter							KEYWORD1
-getDistanceCentimeters					KEYWORD2
-getDistanceInches						KEYWORD2
-updateDistance							KEYWORD2
+DistanceMeter	KEYWORD1
+getDistanceCentimeters	KEYWORD2
+getDistanceInches	KEYWORD2
+updateDistance	KEYWORD2
 ##################################################
-#				DistanceMeterNonBlock     		 #
+#                  DistanceMeterNonBlock         #
 ##################################################
-DistanceMeterNonBlock					KEYWORD1
-updateDistanceNonBlock					KEYWORD2
+DistanceMeterNonBlock	KEYWORD1
+updateDistanceNonBlock	KEYWORD2
 ##################################################
-#				DistanceMeterAccurate     		 #
+#                  DistanceMeterAccurate         #
 ##################################################
-DistanceMeterAccurate					KEYWORD1
+DistanceMeterAccurate	KEYWORD1
 ##################################################
-#				   WaterDetector    		     #
+#                  WaterDetector                 #
 ##################################################
-WaterDetector							KEYWORD1
-begin									KEYWORD2
-end										KEYWORD2
-getWaterStatus							KEYWORD2
-getWaterStatusRange						KEYWORD2
-isWaterDetected							KEYWORD2
+WaterDetector	KEYWORD1
+begin	KEYWORD2
+end	KEYWORD2
+getWaterStatus	KEYWORD2
+getWaterStatusRange	KEYWORD2
+isWaterDetected	KEYWORD2
 ##################################################
-#				    WaterStatus    			     #
+#                  WaterStatus                   #
 ##################################################
-WaterStatus								KEYWORD1
-DRY										LITERAL1
-FEW_DROPS								LITERAL1
-WET										LITERAL1
-FLOOD									LITERAL1
-INVALID									LITERAL1
-NOT_INITIALIZED							LITERAL1
+WaterStatus	KEYWORD1
+DRY	LITERAL1
+FEW_DROPS	LITERAL1
+WET	LITERAL1
+FLOOD	LITERAL1
+INVALID	LITERAL1
+NOT_INITIALIZED	LITERAL1
 ##################################################
-#				    WaterFlowSensor    		     #
+#                  WaterFlowSensor               #
 ##################################################
-WaterFlowSensor							KEYWORD1
-isFlowing								KEYWORD2
+WaterFlowSensor	KEYWORD1
+isFlowing	KEYWORD2
 ##################################################
-#				    WaterFlowMeter    			 #
+#                  WaterFlowMeter                #
 ##################################################
-WaterFlowMeter							KEYWORD1
-getFlowRate								KEYWORD2
+WaterFlowMeter	KEYWORD1
+getFlowRate	KEYWORD2
 ##################################################
-#				     GSMService     		     #
+#                  GSMService                    #
 ##################################################
-GSMService								KEYWORD1
-beginListenForSMS						KEYWORD2
-availableSMS							KEYWORD2
-sendSMS									KEYWORD2
-deleteAllSMS							KEYWORD2
-deleteAllReadSMS						KEYWORD2
-deleteAllSentAndReadSMS					KEYWORD2
+GSMService	KEYWORD1
+beginListenForSMS	KEYWORD2
+availableSMS	KEYWORD2
+sendSMS	KEYWORD2
+deleteAllSMS	KEYWORD2
+deleteAllReadSMS	KEYWORD2
+deleteAllSentAndReadSMS	KEYWORD2
 ##################################################
-#				   GSMServiceSecure    		     #
+#                  GSMServiceSecure              #
 ##################################################
-GSMServiceSecure						KEYWORD1
-addAllowedNumber						KEYWORD2
-isAllowed								KEYWORD2
-removeAllowedNumber						KEYWORD2
-clearAllowedNumbers						KEYWORD2
+GSMServiceSecure	KEYWORD1
+addAllowedNumber	KEYWORD2
+isAllowed	KEYWORD2
+removeAllowedNumber	KEYWORD2
+clearAllowedNumbers	KEYWORD2
 ##################################################
-#				  GSMRequestStatus     		     #
+#                  GSMRequestStatus              #
 ##################################################
-GSMRequestStatus						KEYWORD1
-GSM_OK									LITERAL1
-GSM_UNEXPECTED_REPLY					LITERAL1
-GSM_module_DIDNT_REPLY					LITERAL1
-GSM_SERVICE_NOT_INITIALIZED				LITERAL1
-GSM_REQUEST_INVALID_ARGUMENT			LITERAL1
-GSM_MAXIMUM_ALLOWED_NUMBERS_REACHED		LITERAL1
+GSMRequestStatus	KEYWORD1
+GSM_OK	LITERAL1
+GSM_UNEXPECTED_REPLY	LITERAL1
+GSM_module_DIDNT_REPLY	LITERAL1
+GSM_SERVICE_NOT_INITIALIZED	LITERAL1
+GSM_REQUEST_INVALID_ARGUMENT	LITERAL1
+GSM_MAXIMUM_ALLOWED_NUMBERS_REACHED	LITERAL1
 ##################################################
-#						SMS     		         #
+#                  SMS                           #
 ##################################################
-SMS										KEYWORD1
-getCountryPrefixCode					KEYWORD2
-setCountryPrefixCode					KEYWORD2
-getNumber								KEYWORD2
-setNumber								KEYWORD2
-getMessage								KEYWORD2
-setMessage								KEYWORD2
-reset									KEYWORD2
+SMS	KEYWORD1
+getCountryPrefixCode	KEYWORD2
+setCountryPrefixCode	KEYWORD2
+getNumber	KEYWORD2
+setNumber	KEYWORD2
+getMessage	KEYWORD2
+setMessage	KEYWORD2
+reset	KEYWORD2
 ##################################################
-#							     		         #
+#	                                               #
 ##################################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords